### PR TITLE
Adding retries for follow errors or bad json

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -2,5 +2,6 @@
     "ua": "npm-registry-follower",
     "registry": "https://registry.npmjs.org/",
     "skim": "https://skimdb.npmjs.com/registry",
-    "seqFile": "/tmp/registry-follow.seq"
+    "seqFile": "/tmp/registry-follow.seq",
+    "retries": 5
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -8,7 +8,10 @@ var request = require('request');
 var url = require('url');
 var config = require('./config.json');
 
+var tries = 0;
+
 var getDoc = function(change, callback) {
+    tries++;
     var opt = {
         url: config.registry + change.id,
         json: true,
@@ -17,9 +20,13 @@ var getDoc = function(change, callback) {
         }
     };
     request.get(opt, function(err, res, json) {
-        if (err) {
+        if (err || !json) {
             console.error(err);
+            if (tries < config.retries) {
+                return getDoc(change, callback);
+            }
         }
+        tries = 0;
         callback(err, json, change);
     });
 };


### PR DESCRIPTION
@bengl This might help us out a little with invalid changes coming into `registry-static`. If the follow change errs out, we retry it (up to 5 times). Thoughts?
