### PR TITLE
wait for registry to catch up

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -19,11 +19,29 @@ var getDoc = function(change, callback) {
     request.get(opt, function(err, res, json) {
         if (err) {
             console.error(err);
+            return callback(err, json, change);
         }
-        callback(err, json, change);
+
+        // check if the rev in the json is the same or newer than change data.
+        // if it's older, wait and try again in a minute.
+        // if there's no json and rev # is 1, then it's a brand new package, so
+        // just wait and try again.
+        var rev = getRev(change.changes[0].rev);
+        var retry = json ? getRev(json._rev) < rev : rev === 1;
+        if (retry) {
+            // wait a minute. try again.
+            return setTimeout(function(){
+                return getDoc(change, callback);
+            }, 60000);
+        }
+        callback(null, json, change);
     });
 };
 exports.get = getDoc;
+
+var getRev = function(_rev) {
+    return _rev.split('-')[0]
+};
 
 var splitVersions = function(json) {
     var parts = [];

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,7 +6,7 @@ var noop = function() {};
 
 var followMock = function(opts, change) {
     process.nextTick(function() {
-        change(null, {});
+        change(null, {id: 'async', changes: [{rev: '806-539c2faa42188c0d254280e9afaa0c6e'}]});
     });
     return {
         pause: noop,


### PR DESCRIPTION
Sometimes, the registry isn't quite up to date with the changes feed, so
when follow-registry makes a request to the registry to get the latest
metadata, it's one version too old. This change checks the _rev on the
metadata against the rev provided in the changes feed. It's it's too
old, it waits a minute and tries again.
