### PR TITLE
don't retry if change is a deletion

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -25,15 +25,19 @@ var getDoc = function(change, callback) {
         // check if the rev in the json is the same or newer than change data.
         // if it's older, wait and try again in a minute.
         // if there's no json and rev # is 1, then it's a brand new package, so
-        // just wait and try again.
+        // just wait and try again. ignore if deleted
         var retry;
-        try{
-            var rev = getRev(change.changes[0].rev);
-            retry = json ? getRev(json._rev) < rev : rev === 1;
-        } catch (e) {
-            // errors happen if there's some bad json. ignore them since
-            // there's nothing we can do.
-            console.error(e.stack);
+        if (change.deleted) {
+            retry = false;
+        } else {
+            try {
+                var rev = getRev(change.changes[0].rev);
+                retry = json ? getRev(json._rev) < rev : rev === 1;
+            } catch (e) {
+                // errors happen if there's some bad json. ignore them since
+                // there's nothing we can do.
+                console.error(e.stack);
+            }
         }
         if (retry) {
             // wait a minute. try again.


### PR DESCRIPTION
When a deletion/unpublish happens, the change rev will always be greater
than the one on registry.npmjs.org, so the rev-checking logic would get
into an infinite loop. This is now short-circuited in the case of
deletions, to prevent that infinite loop.
