### PR TITLE
retry limit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,9 @@ var mix = function(c) {
     if (!config.handler) {
         throw("a change handler must be provided in the config..");
     }
+    if (!config.logger) {
+        config.logger = console;
+    }
 };
 
 var start = function(c, callback) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -8,7 +8,8 @@ var request = require('request');
 var url = require('url');
 var config = require('./config.json');
 
-var getDoc = function(change, callback) {
+var getDoc = function(change, callback, retries) {
+    retries = retries || 0;
     var opt = {
         url: config.registry + change.id,
         json: true,
@@ -27,7 +28,7 @@ var getDoc = function(change, callback) {
         // if there's no json and rev # is 1, then it's a brand new package, so
         // just wait and try again. ignore if deleted
         var retry;
-        if (change.deleted) {
+        if (retries >= 5 || change.deleted) {
             retry = false;
         } else {
             try {
@@ -39,10 +40,11 @@ var getDoc = function(change, callback) {
                 console.error(e.stack);
             }
         }
+        // TODO add some logging around retry reasons
         if (retry) {
             // wait a minute. try again.
             return setTimeout(function(){
-                return getDoc(change, callback);
+                return getDoc(change, callback, retries+1);
             }, 60000);
         }
         callback(null, json, change);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -7,6 +7,7 @@ See LICENSE file.
 var request = require('request');
 var url = require('url');
 var config = require('./config.json');
+logger = config.logger;
 
 var getDoc = function(change, callback, retries) {
     retries = retries || 0;
@@ -28,7 +29,10 @@ var getDoc = function(change, callback, retries) {
         // if there's no json and rev # is 1, then it's a brand new package, so
         // just wait and try again. ignore if deleted
         var retry;
-        if (retries >= 5 || change.deleted) {
+        if (retries >= 5) {
+            logger.log('retry limit reached for', change.id, 'revision', change.changes[0].rev);
+            retry = false;
+        } else if (change.deleted) {
             retry = false;
         } else {
             try {
@@ -40,7 +44,6 @@ var getDoc = function(change, callback, retries) {
                 console.error(e.stack);
             }
         }
-        // TODO add some logging around retry reasons
         if (retry) {
             // wait a minute. try again.
             return setTimeout(function(){


### PR DESCRIPTION
For now, setting this to 5. In the future we may not need this at all,
if we stop using registry.npmjs.org.
