### PR TITLE
use skimdb always

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -1,6 +1,6 @@
 {
     "ua": "npm-registry-follower",
-    "registry": "https://registry.npmjs.org/",
+    "registry": "https://skimdb.npmjs.com/registry/",
     "skim": "https://skimdb.npmjs.com/registry",
     "seqFile": "/tmp/registry-follow.seq"
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -23,32 +23,6 @@ var getDoc = function(change, callback, retries) {
             return callback(err, json, change);
         }
 
-        // check if the rev in the json is the same or newer than change data.
-        // if it's older, wait and try again in a minute.
-        // if there's no json and rev # is 1, then it's a brand new package, so
-        // just wait and try again. ignore if deleted
-        var retry;
-        if (retries >= 5) {
-            config.logger.log('retry limit reached for', change.id, 'revision', change.changes[0].rev);
-            retry = false;
-        } else if (change.deleted) {
-            retry = false;
-        } else {
-            try {
-                var rev = getRev(change.changes[0].rev);
-                retry = json ? getRev(json._rev) < rev : rev === 1;
-            } catch (e) {
-                // errors happen if there's some bad json. ignore them since
-                // there's nothing we can do.
-                console.error(e.stack);
-            }
-        }
-        if (retry) {
-            // wait a minute. try again.
-            return setTimeout(function(){
-                return getDoc(change, callback, retries+1);
-            }, 60000);
-        }
         callback(null, json, change);
     });
 };


### PR DESCRIPTION
Apart from random bad data, there are two main differences between `skimdb` and `registry.npmjs.org`:
1. `skimdb` doesn't show the irrelevant and empty `_attachments` and `directories` objects.
2. `registry.npmjs.org` gives a 404 instead of details for deleted packages.

That's basically it, so it should be reasonable to use only `skimdb` for all the data.

Also removing the retry stuff, as it's pointless once we're only pointing at the one registry.
