### PR TITLE
Fixed Memory Pointer Reuse

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -34,21 +34,23 @@ var getRev = function(_rev) {
 
 var splitVersions = function(json) {
     var parts = [];
+
+    function addVersionAs(name, version) {
+        parts.push({
+            version: name,
+            json: JSON.parse(JSON.stringify(json.versions[version]))
+        });
+    }
+
     if (json['dist-tags']) {
         Object.keys(json['dist-tags']).forEach(function(name) {
             var tag = json['dist-tags'][name];
-            parts.push({
-                version: name,
-                json: json.versions[tag]
-            });
+            addVersionAs(name, tag);
         });
     }
     if (json.versions) {
         Object.keys(json.versions).forEach(function(name) {
-            parts.push({
-                version: name,
-                json: json.versions[name]
-            });
+            addVersionAs(name, name);
         });
     }
     return parts;

--- a/tests/index.js
+++ b/tests/index.js
@@ -58,6 +58,17 @@ var tests = {
         },
         'and return change': function(d) {
             assert.ok(d);
+        },
+        'and not reuse memory pointers': function(d) {
+            d.versions.forEach(function(item) {
+                var itemVersionObject = item.json;
+                var rootVersionObject = d.json.versions[itemVersionObject.version];
+                // Assert that json objects are distinct.
+                assert.isFalse(
+                    itemVersionObject === rootVersionObject,
+                    'Memory pointers are identical at "' + item.version + '"'
+                );
+            });
         }
     }
 };


### PR DESCRIPTION
Construction of the follower's versions array re-referenced objects from
the original JSON body, effectively creating multiple pointers to the
same object instance. Downstream uses, such as the one linked below,
will then unknowingly apply a change against the same instance twice, leading
to unexpected behavior.

https://github.com/davglass/registry-static/blob/master/lib/index.js#L126
