### PR TITLE
@scope support: replace urls: replicate.npmjs.com

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -1,7 +1,7 @@
 {
     "ua": "npm-registry-follower",
-    "registry": "https://skimdb.npmjs.com/registry/",
-    "skim": "https://skimdb.npmjs.com/registry",
+    "registry": "https://replicate.npmjs.com/",
+    "skim": "https://replicate.npmjs.com",
     "seqFile": "/tmp/registry-follow.seq",
     "concurrency": 100,
     "inactivity_ms": 3600000


### PR DESCRIPTION
This commit replaces the URLs as discussed at https://github.com/davglass/registry-static/issues/70.
## skimdb url replacement

The outages from using skimdb had a lot of followers to change the URL to the new replicate one.

http://status.npmjs.org/incidents/669mzfs17fkr
## Benefits: `@scope` support

This replacement also provides support to public `@scoped` libraries. See the discussing in the URL above for details
